### PR TITLE
修复因为链接数据库名填写的是大写导致无法判断表格是否存在

### DIFF
--- a/src/ShardingCore/TableExists/MySqlTableEnsureManager.cs
+++ b/src/ShardingCore/TableExists/MySqlTableEnsureManager.cs
@@ -18,7 +18,7 @@ namespace ShardingCore.TableExists
 
         public override ISet<string> DoGetExistTables(DbConnection connection, string dataSourceName)
         {
-            var database = connection.Database;
+            var database = connection.Database.ToLower();
             ISet<string> result = new HashSet<string>();
             using (var dataTable = connection.GetSchema(Tables))
             {


### PR DESCRIPTION
我发现如果数据库链接填写的Database是大写的会导致无法判断是否已经创建表格,因为mysql返回的是小写